### PR TITLE
Fix the extension for non-www songsterr urls

### DIFF
--- a/SongsterrPremium/src/background.js
+++ b/SongsterrPremium/src/background.js
@@ -5,6 +5,8 @@ chrome.webRequest.onBeforeRequest.addListener(
     urls: [
       "http://www.songsterr.com/a/wa/enabledFeatures?songId=*",
       "https://www.songsterr.com/a/wa/enabledFeatures?songId=*",
+      "http://songsterr.com/a/wa/enabledFeatures?songId=*",
+      "https://songsterr.com/a/wa/enabledFeatures?songId=*",
     ]
   },
   ["blocking"]

--- a/SongsterrPremium/src/manifest.json
+++ b/SongsterrPremium/src/manifest.json
@@ -3,7 +3,7 @@
   "version": "1.1",
   "author": "Creeplays",
   "description": "All premium features! (Created by F6CF (aka Creeplays))",
-  "permissions": ["webRequest", "webRequestBlocking", "http://www.songsterr.com/*","https://www.songsterr.com/*"],
+  "permissions": ["webRequest", "webRequestBlocking", "http://www.songsterr.com/*", "http://songsterr.com/*","https://www.songsterr.com/*","https://songsterr.com/*"],
   "background": {
     "scripts": ["background.js"]
   },
@@ -11,7 +11,9 @@
     {
       "matches": [
         "http://www.songsterr.com/a/wa/*","https://www.songsterr.com/a/wa/*",
-        "http://www.songsterr.com/a/wsa/*","https://www.songsterr.com/a/wsa/*"
+        "http://songsterr.com/a/wa/*","https://songsterr.com/a/wa/*",
+        "http://www.songsterr.com/a/wsa/*","https://www.songsterr.com/a/wsa/*",
+        "http://songsterr.com/a/wsa/*","https://songsterr.com/a/wsa/*"
       ],
       "js": ["patchState.js"]
     }


### PR DESCRIPTION
I noticed that the premium extension wouldn't always work. Apparently the reason was that I sometimes typed `songsterr.com` instead of `www.songsterr.com`. So I just added the non-www URLs and now it works fine. It even works in Firefox btw. It would be nice to have builds for that too. 

I leave changing the version number and building the new version to you. Unless you want me to do it...